### PR TITLE
Add JMX metrics gatherer version 1.48.0-alpha

### DIFF
--- a/.chloggen/add-jmx-metrics-gatherer-1.48.0-alpha.yaml
+++ b/.chloggen/add-jmx-metrics-gatherer-1.48.0-alpha.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: jmxreceiver
+note: Add the JMX metrics gatherer version 1.48.0-alpha to the supported jars hash list
+issues: [ 2 ]

--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,6 +31,10 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
+	"dd1ab4cb7fd45c30cf4e8090f9289a42b2c7bc1e7377536eef2c40c51d8641ae": {
+		version: "1.48.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
 	"0344be738295602718934accd0557496b10464582681e69a251dc3b8d3f69b69": {
 		version: "1.47.0-alpha",
 		jar:     "JMX metrics gatherer",


### PR DESCRIPTION
Add JMX metrics gatherer version `1.48.0-alpha`.

cc @open-telemetry/java-contrib-approvers
