### PR TITLE
Add JMX metrics gatherer version 1.55.0-alpha

### DIFF
--- a/.chloggen/add-jmx-metrics-gatherer-1.55.0-alpha.yaml
+++ b/.chloggen/add-jmx-metrics-gatherer-1.55.0-alpha.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: jmxreceiver
+note: Add the JMX metrics gatherer version 1.55.0-alpha to the supported jars hash list
+issues: [ 9 ]

--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,6 +31,10 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
+	"af32d2c1be2f8e4b675f48161ffdb4a4d08cabfd1620a723a7534c7e19cc0a18": {
+		version: "1.55.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
 	"0344be738295602718934accd0557496b10464582681e69a251dc3b8d3f69b69": {
 		version: "1.47.0-alpha",
 		jar:     "JMX metrics gatherer",


### PR DESCRIPTION
Add JMX metrics gatherer version `1.55.0-alpha`.

cc @open-telemetry/java-contrib-approvers
