### PR TITLE
Add JMX metrics gatherer version 1.57.0-alpha

### DIFF
--- a/.chloggen/add-jmx-metrics-gatherer-1.57.0-alpha.yaml
+++ b/.chloggen/add-jmx-metrics-gatherer-1.57.0-alpha.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: jmxreceiver
+note: Add the JMX metrics gatherer version 1.57.0-alpha to the supported jars hash list
+issues: [ 11 ]

--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -31,6 +31,10 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 // If you change this variable name, please open an issue in opentelemetry-java-contrib
 // so that repository's release automation can be updated
 var jmxMetricsGathererVersions = map[string]supportedJar{
+	"1dc26f7561e4cfed632b37ce14d3e9853026d683f6c43c1e4228095213201f9f": {
+		version: "1.57.0-alpha",
+		jar:     "JMX metrics gatherer",
+	},
 	"0344be738295602718934accd0557496b10464582681e69a251dc3b8d3f69b69": {
 		version: "1.47.0-alpha",
 		jar:     "JMX metrics gatherer",


### PR DESCRIPTION
Add JMX metrics gatherer version `1.57.0-alpha`.

cc @open-telemetry/java-contrib-approvers
